### PR TITLE
Fix `create_pool` to be a coroutine

### DIFF
--- a/asyncpg-stubs/pool.pyi
+++ b/asyncpg-stubs/pool.pyi
@@ -620,7 +620,7 @@ class PoolAcquireContext(Generic[_Record]):
     ) -> Generator[Any, None, PoolConnectionProxy[_Record]]: ...
 
 @overload
-def create_pool(
+async def create_pool(
     dsn: str | None = ...,
     *,
     min_size: int = ...,
@@ -649,7 +649,7 @@ def create_pool(
     server_settings: dict[str, str] | None = ...,
 ) -> Pool[_Record]: ...
 @overload
-def create_pool(
+async def create_pool(
     dsn: str | None = ...,
     *,
     min_size: int = ...,


### PR DESCRIPTION
This change updates the `create_pool` function in `asyncpg-stubs/pool.pyi` to be defined as an async coroutine, reflecting its true behavior.